### PR TITLE
feat: reduce requests to same leader, add leader buffer, and improve metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,7 @@ dependencies = [
  "futures",
  "futures-channel",
  "futures-sink",
+ "indexmap 2.2.5",
  "jsonrpsee",
  "jsonrpsee-types 0.18.2",
  "rand 0.8.5",
@@ -1917,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -2680,7 +2681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
 ]
 
 [[package]]
@@ -3676,7 +3677,7 @@ dependencies = [
  "dashmap 4.0.2",
  "futures",
  "futures-util",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "indicatif",
  "log",
  "quinn",
@@ -3722,7 +3723,7 @@ dependencies = [
  "bincode",
  "crossbeam-channel",
  "futures-util",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "log",
  "rand 0.8.5",
  "rayon",
@@ -4171,7 +4172,7 @@ dependencies = [
  "crossbeam-channel",
  "futures-util",
  "histogram",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "itertools",
  "libc",
  "log",
@@ -4216,7 +4217,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "futures-util",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "indicatif",
  "log",
  "rayon",
@@ -4901,7 +4902,7 @@ version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "toml_datetime",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ yellowstone-grpc-client = { git = "https://github.com/helius-labs/yellowstone-gr
 futures-channel = "0.3.30"
 futures-sink = "0.3.30"
 rand = "0.8.5"
+indexmap = "2.2.5"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.5"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The service has the following envs:
 
 `NUM_LEADERS` - Number of leaders to send transactions to
 
+`LEADER_OFFSET` - Offset of the leader schedule. Default is 0. 
+
 `IDENTITY_KEYPAIR_FILE` - Path to the keypair file. If this is a validator key it will use a staked connection to connect to leaders.
 
 `PORT` - Port to run the service on. Default is 4040.

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,7 @@ async fn main() -> anyhow::Result<()> {
     let transaction_store = Arc::new(TransactionStoreImpl::new());
     let solana_rpc = Arc::new(GrpcGeyserImpl::new(client));
     let rpc_client = Arc::new(RpcClient::new(env.rpc_url.unwrap()));
-    let num_leaders = env.num_leaders.unwrap_or(4);
+    let num_leaders = env.num_leaders.unwrap_or(2);
     let leader_tracker = Arc::new(LeaderTrackerImpl::new(
         rpc_client,
         solana_rpc.clone(),


### PR DESCRIPTION
1. NUM_LEADERS was previously controlling the number of slots. Each leader handles 4 slots. This meant it would send 4 requests to the same leader. This will reduce the contention on the leader.
2. Add leader buffer (optional) if you want to skip the current N leaders.
3. Improve metrics, including priority fee, compute unit, and the priority (the weight used by the scheduler). The metrics are published as gauges to reduce cardinality.