### PR TITLE
Add support for `send_transaction_bundle()`

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,11 +1,22 @@
 use std::error::Error;
 
-use jsonrpsee::types::{error::INVALID_PARAMS_CODE, ErrorObjectOwned};
+use jsonrpsee::types::{
+    error::{INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE},
+    ErrorObjectOwned,
+};
 
 pub fn invalid_request(reason: &str) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(
         INVALID_PARAMS_CODE,
         format!("Invalid Request: {reason}"),
+        None::<String>,
+    )
+}
+
+pub fn internal_error(reason: &str) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(
+        INTERNAL_ERROR_CODE,
+        format!("Internal Error: {reason}"),
         None::<String>,
     )
 }


### PR DESCRIPTION
This PR adds support for a new API called `send_transaction_bundle()` as per the definition listed here - https://helius-api.notion.site/Take-home-sendTransactionBundle-1a10b5a55cc580c29c1fff9fd8088e4e

Assumptions:
1. `send_transaction_bundle()`
    - Returns a list of signatures of successful transactions. Returns `TransportError` on failures
    - Carries out preflight checks for each transaction in the list (via `preflight_check()`
    - Reuses the existing `send_transaction()` method to send the transactions
2. `send_transaction()`
    - Checks whether transaction is either `confirmed` or `finalized` and succeeded before sending transaction to reduce no-op/invalid transactions. If `true`, we set the flag `transaction_confirmed_or_finalized = true` and stop sending transactions. 
        - I am setting the flag to true in this case to increase the redundancy of the transaction data across multiple leaders. See Limitations section, point 2 for more details.
        - Ideally we could also do on-chain verification (especially blockhash checks) in between retries since the blockhash could potentially expire between . I haven't done this in the code to keep it simple and since the on-chain verification could potentially add more latency. It's preferable to have the retry fail instead of spending more time checking between retries.
    - Carries out onchain verification (blockhash, signature, message validity) before sending transaction to reduce invalid transactions
    - If transaction is confirmed/finalized and successful, returns the signer's signature of the transaction. Otherwise returns `TransportError`
3. `transaction_confirmed_or_finalized_and_successful()`
    - Validates whether a transaction has the `confirmed` or `finalized` commitment level and has succeeded
    - Assuming `confirmed` and `finalized` to ensure higher chances of transaction commitment finality. Checking for `finalized` is time consuming but it guarantees completion. I chose safety over latency by including `finalized` in the checks.
4. `preflight_checks()`
    - Validates the signatures and blockhash validity
    - Could potentially also validate the accounts linked with the transaction but I skipped that
5. `transaction_committed_and_successful()` and `check_blockhash_validity()`
    - Helper functions to reuse available functionality from Solana RPC client to help with validation
    - Assumed that it's okay to use the existing functions instead of reinventing the wheel

Limitations:
1. `preflight_check()` does not validate account ids
2. `send_transaction()` 
    - Ideally we set return some value (bool, txn signature, etc) in `JoinHandle` i.e. `self.txn_sender_runtime.spawn` code when the transaction is received successfully by leader. This can be used to break out of the for loop  which prevents sending the transaction to subsequent leaders. If this was done, in the best case scenario only 1 leader will receive the transaction (high latency, no redundancy). Doing so improves the performance but there will be no redundancy amongst the leaders with regards to the transaction data. I have traded off redundancy over latency in this scenario.
 3. `send_transaction_bundle()`
     - Currently, this function errors out if even one of the transactions in the list errors out. This prevents us from seeing any transactions that were successful prior to the failing transaction. This could be refactored to include only successful transaction signatures regardless of whether future transaction errors out. An empty vector/array would mean all transactions failed. The output depends on the expectations of the system:
         - If we want to be defensive (as the current implementation does): return and bubble up error even if some transactions within the list succeeded 
         - If we want to be optimistic: return the list of successful transactions even if some failed


Note: I did not get a chance to deploy  test the code, but `cargo build` builds successfully. There are no errors in that regard and the code has been formatted using `cargo fmt`. If time permitted, I would have also added unit and integration tests.